### PR TITLE
[feature] CI 테스트

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,8 +30,8 @@ jobs:
         distribution: 'temurin'
     - name: Build with Gradle
       run: chmod +x gradlew
-    - name: Test with Gradle # test application build
-      run: ./gradlew test
+#     - name: Test with Gradle # test application build
+#       run: ./gradlew test
     - name: Build with Gradle
       run: ./gradlew build -x test
     - name: Temporarily save build artifact


### PR DESCRIPTION
* 🎨 CI 테스트를 위해 ./gradlew test 누락

테스트 코드가 없어서 빌드 실패

테스트를 진행하지 않으면 빌드가 되는지 확인

[진행 기록 노션](https://king-zeze.notion.site/Github-Action-CI-4db29adcebea41c69cbb3984987e9c93)

