### PR TITLE
🎨 Record + Record Flavor 조회 및 저장기능 추가

### DIFF
--- a/src/main/java/com/depromeet/sulsul/domain/beerFlavor/dto/BeerFlavorRecordDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/beerFlavor/dto/BeerFlavorRecordDto.java
@@ -1,0 +1,4 @@
+package com.depromeet.sulsul.domain.beerFlavor.dto;
+
+public class BeerFlavorRecordDto {
+}

--- a/src/main/java/com/depromeet/sulsul/domain/beerFlavor/dto/BeerFlavorRequest.java
+++ b/src/main/java/com/depromeet/sulsul/domain/beerFlavor/dto/BeerFlavorRequest.java
@@ -1,0 +1,18 @@
+package com.depromeet.sulsul.domain.beerFlavor.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BeerFlavorRequest {
+    private Long beerId;
+    private List<Long> flavorIds = new ArrayList<>();
+}

--- a/src/main/java/com/depromeet/sulsul/domain/beerFlavor/repository/BeerFlavorRepository.java
+++ b/src/main/java/com/depromeet/sulsul/domain/beerFlavor/repository/BeerFlavorRepository.java
@@ -1,0 +1,10 @@
+package com.depromeet.sulsul.domain.beerFlavor.repository;
+
+import com.depromeet.sulsul.domain.beerFlavor.entity.BeerFlavor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BeerFlavorRepository extends JpaRepository<BeerFlavor, Long> {
+
+}

--- a/src/main/java/com/depromeet/sulsul/domain/beerFlavor/service/BeerFlavorService.java
+++ b/src/main/java/com/depromeet/sulsul/domain/beerFlavor/service/BeerFlavorService.java
@@ -1,0 +1,40 @@
+package com.depromeet.sulsul.domain.beerFlavor.service;
+
+import com.depromeet.sulsul.domain.beer.entity.Beer;
+import com.depromeet.sulsul.domain.beer.repository.BeerRepository;
+import com.depromeet.sulsul.domain.beerFlavor.dto.BeerFlavorRequest;
+import com.depromeet.sulsul.domain.beerFlavor.entity.BeerFlavor;
+import com.depromeet.sulsul.domain.beerFlavor.repository.BeerFlavorRepository;
+import com.depromeet.sulsul.domain.flavor.repository.FlavorRepository;
+import com.depromeet.sulsul.domain.record.entity.Record;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BeerFlavorService {
+    private final BeerFlavorRepository beerFlavorRepository;
+    private final BeerRepository beerRepository;
+    private final FlavorRepository flavorRepository;
+
+    @Transactional
+    public void save(BeerFlavorRequest beerFlavorRequest, Record record){
+        List<BeerFlavor> beerFlavorList = new ArrayList<>();
+        Beer beer = beerRepository.getById(beerFlavorRequest.getBeerId());
+        for(int i=0; i<beerFlavorRequest.getFlavorIds().size(); i++){
+            beerFlavorList.add(new BeerFlavor(
+                        beer
+                        , flavorRepository.getById(beerFlavorRequest.getFlavorIds().get(i))
+                        , record
+                    )
+            );
+        }
+        beerFlavorRepository.saveAll(beerFlavorList);
+    }
+
+}

--- a/src/main/java/com/depromeet/sulsul/domain/flavor/dto/FlavorDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/flavor/dto/FlavorDto.java
@@ -1,0 +1,13 @@
+package com.depromeet.sulsul.domain.flavor.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class FlavorDto {
+    private Long id;
+    private String content;
+}

--- a/src/main/java/com/depromeet/sulsul/domain/flavor/entity/Flavor.java
+++ b/src/main/java/com/depromeet/sulsul/domain/flavor/entity/Flavor.java
@@ -17,4 +17,9 @@ public class Flavor {
     private Long id;
 
     private String content;
+
+    public Flavor(Long id, String content) {
+        this.id = id;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/depromeet/sulsul/domain/flavor/repository/FlavorRepository.java
+++ b/src/main/java/com/depromeet/sulsul/domain/flavor/repository/FlavorRepository.java
@@ -1,0 +1,9 @@
+package com.depromeet.sulsul.domain.flavor.repository;
+
+import com.depromeet.sulsul.domain.flavor.entity.Flavor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FlavorRepository extends JpaRepository<Flavor, Long> {
+}

--- a/src/main/java/com/depromeet/sulsul/domain/member/dto/MemberRecordDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/member/dto/MemberRecordDto.java
@@ -1,0 +1,18 @@
+package com.depromeet.sulsul.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberRecordDto {
+    private static final long serialVersionUID = -3240908099376045282L;
+
+    private Long id;
+    private String name;
+    private String profileUrl;
+}

--- a/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
@@ -1,0 +1,36 @@
+package com.depromeet.sulsul.domain.record.controller;
+
+import com.depromeet.sulsul.common.response.dto.PageableResponse;
+import com.depromeet.sulsul.common.response.dto.ResponseDto;
+import com.depromeet.sulsul.domain.beerFlavor.dto.BeerFlavorRequest;
+import com.depromeet.sulsul.domain.beerFlavor.service.BeerFlavorService;
+import com.depromeet.sulsul.domain.record.dto.RecordDto;
+import com.depromeet.sulsul.domain.record.dto.RecordRequest;
+import com.depromeet.sulsul.domain.record.entity.Record;
+import com.depromeet.sulsul.domain.record.service.RecordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class RecordController {
+    private final RecordService recordService;
+    private final BeerFlavorService beerFlavorService;
+
+    @PostMapping("/record")
+    public ResponseEntity<Object> save(@RequestBody RecordRequest recordRequest
+                                       , @RequestBody BeerFlavorRequest beerFlavorRequest){
+        Record recordSave = recordService.save(recordRequest);
+        beerFlavorService.save(beerFlavorRequest, recordSave);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/record")
+    public ResponseDto<PageableResponse<RecordDto>> findAllRecordsWithPageable(@RequestParam("beerId") Long beerId
+                                                                , @RequestParam("recordId") Long recordId){
+        return ResponseDto.of(recordService.findAllRecordsWithPageable(beerId, recordId));
+    }
+}

--- a/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordDto.java
@@ -1,0 +1,45 @@
+package com.depromeet.sulsul.domain.record.dto;
+
+import com.depromeet.sulsul.domain.flavor.dto.FlavorDto;
+import com.depromeet.sulsul.domain.flavor.entity.Flavor;
+import com.depromeet.sulsul.domain.member.dto.MemberRecordDto;
+import com.depromeet.sulsul.domain.member.entity.Member;
+import com.depromeet.sulsul.domain.recordFlavor.entity.RecordFlavor;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RecordDto {
+    private String content;
+    private String memberName;
+    private String memberProfileurl;
+    private Integer feel;
+    private Integer score;
+    private List<Flavor> flavor;
+
+    @QueryProjection
+    public RecordDto(String content, Member member, Integer feel, Integer score, List<Flavor> flavor) {
+        this.content = content;
+        this.memberName = member.getName();
+        this.memberProfileurl = member.getProfileUrl();
+        this.feel = feel;
+        this.score = score;
+
+        this.flavor = flavor;
+    }
+
+    @QueryProjection
+    public RecordDto(String content, Integer feel, Integer score) {
+        this.content = content;
+        this.feel = feel;
+        this.score = score;
+    }
+}

--- a/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordRequest.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordRequest.java
@@ -1,0 +1,18 @@
+package com.depromeet.sulsul.domain.record.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecordRequest {
+    private String content;
+    private Long memberId;
+    private Long beerId;
+    private Integer feel;
+    private Integer score;
+}

--- a/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordUpdateRequest.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.depromeet.sulsul.domain.record.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecordUpdateRequest {
+    private Long id;
+    private String content;
+    private Long memberId;
+    private Long beerId;
+    private Integer feel;
+    private Integer score;
+}

--- a/src/main/java/com/depromeet/sulsul/domain/record/entity/Record.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/entity/Record.java
@@ -1,12 +1,17 @@
 package com.depromeet.sulsul.domain.record.entity;
 
 import com.depromeet.sulsul.domain.beer.entity.Beer;
+import com.depromeet.sulsul.domain.flavor.entity.Flavor;
 import com.depromeet.sulsul.domain.member.entity.Member;
+import com.depromeet.sulsul.domain.recordFlavor.entity.RecordFlavor;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -25,8 +30,20 @@ public class Record {
     @JoinColumn(name = "beer_id")
     private Beer beer;
 
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "record")
+    private List<RecordFlavor> recordFlavors = new ArrayList<>();
+
     private String content;
-    private Boolean isPublic;
+    private Boolean isPublic = false;
     private Integer feel;
     private Integer score;
+    private Boolean isDeleted = false;
+
+    public Record(String content, Integer feel, Integer score, Member member, Beer beer) {
+        this.content = content;
+        this.feel = feel;
+        this.score = score;
+        this.member = member;
+        this.beer = beer;
+    }
 }

--- a/src/main/java/com/depromeet/sulsul/domain/record/repository/RecordRepository.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/repository/RecordRepository.java
@@ -1,0 +1,11 @@
+package com.depromeet.sulsul.domain.record.repository;
+
+import com.depromeet.sulsul.domain.record.entity.Record;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecordRepository extends JpaRepository<Record, Long>, RecordRepositoryCustom, QuerydslPredicateExecutor<Record> {
+
+}

--- a/src/main/java/com/depromeet/sulsul/domain/record/repository/RecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/repository/RecordRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.depromeet.sulsul.domain.record.repository;
+
+import com.depromeet.sulsul.domain.record.dto.RecordDto;
+import com.depromeet.sulsul.domain.record.entity.Record;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RecordRepositoryCustom {
+
+    List<Record> findAllRecordsWithPageable(Long beerId, Long recordId);
+
+}

--- a/src/main/java/com/depromeet/sulsul/domain/record/repository/RecordRepositoryCustomImpl.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/repository/RecordRepositoryCustomImpl.java
@@ -1,0 +1,42 @@
+package com.depromeet.sulsul.domain.record.repository;
+
+import com.depromeet.sulsul.domain.flavor.entity.QFlavor;
+import com.depromeet.sulsul.domain.member.entity.QMember;
+import com.depromeet.sulsul.domain.record.dto.QRecordDto;
+import com.depromeet.sulsul.domain.record.dto.RecordDto;
+import com.depromeet.sulsul.domain.record.entity.QRecord;
+import com.depromeet.sulsul.domain.record.entity.Record;
+import com.depromeet.sulsul.domain.recordFlavor.entity.QRecordFlavor;
+import com.depromeet.sulsul.util.PaginationUtil;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.hibernate.Hibernate;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.OneToMany;
+import java.util.List;
+
+import static com.depromeet.sulsul.domain.flavor.entity.QFlavor.*;
+import static com.depromeet.sulsul.domain.record.entity.QRecord.record;
+import static com.depromeet.sulsul.domain.recordFlavor.entity.QRecordFlavor.*;
+
+@Repository
+public class RecordRepositoryCustomImpl implements RecordRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    public RecordRepositoryCustomImpl(EntityManager entityManager) {
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public List<Record> findAllRecordsWithPageable(Long beerId, Long recordId){
+        List<Record> recordDtos = queryFactory.select(record)
+                .from(record)
+                .where(record.id.goe(recordId))
+                .limit(PaginationUtil.PAGINATION_SIZE+1)
+                .fetch();
+        return recordDtos;
+    }
+
+}

--- a/src/main/java/com/depromeet/sulsul/domain/record/service/RecordService.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/service/RecordService.java
@@ -1,0 +1,61 @@
+package com.depromeet.sulsul.domain.record.service;
+
+import com.depromeet.sulsul.common.response.dto.PageableResponse;
+import com.depromeet.sulsul.domain.beer.repository.BeerRepository;
+import com.depromeet.sulsul.domain.flavor.entity.Flavor;
+import com.depromeet.sulsul.domain.member.repository.MemberRepository;
+import com.depromeet.sulsul.domain.record.dto.RecordDto;
+import com.depromeet.sulsul.domain.record.dto.RecordRequest;
+import com.depromeet.sulsul.domain.record.entity.Record;
+import com.depromeet.sulsul.domain.record.repository.RecordRepository;
+import com.depromeet.sulsul.domain.recordFlavor.entity.RecordFlavor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.depromeet.sulsul.util.PaginationUtil.PAGINATION_SIZE;
+import static com.depromeet.sulsul.util.PaginationUtil.isOverPaginationSize;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RecordService {
+    private final RecordRepository recordRepository;
+    private final BeerRepository beerRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Record save(RecordRequest recordRequest){
+        return recordRepository.save(new Record(
+                recordRequest.getContent()
+                , recordRequest.getFeel()
+                , recordRequest.getScore()
+                , memberRepository.getById(recordRequest.getMemberId())
+                , beerRepository.getById(recordRequest.getBeerId())
+        ));
+    }
+
+    public PageableResponse<RecordDto> findAllRecordsWithPageable(Long beerId, Long recordId){
+        List<Record> allRecordsWithPageable = recordRepository.findAllRecordsWithPageable(beerId, recordId);
+        List<RecordDto> allRecordDtosWithPageable = new ArrayList<>();
+        PageableResponse<RecordDto> recordDtoPageableResponse = new PageableResponse<>();
+        for (Record record : allRecordsWithPageable) {
+            List<RecordFlavor> recordFlavors = record.getRecordFlavors();
+            List<Flavor> flavors = new ArrayList<>();
+            for (RecordFlavor recordFlavor : recordFlavors) {
+                flavors.add(recordFlavor.getFlavor());
+            }
+            allRecordDtosWithPageable.add(new RecordDto(record.getContent(), record.getMember(),
+                    record.getFeel(), record.getScore(), flavors));
+        }
+        if(isOverPaginationSize(allRecordDtosWithPageable)){
+            allRecordDtosWithPageable.remove(PAGINATION_SIZE);
+            recordDtoPageableResponse.setHasNext(true);
+        }
+        recordDtoPageableResponse.setContents(allRecordDtosWithPageable);
+        return recordDtoPageableResponse;
+    }
+}

--- a/src/main/java/com/depromeet/sulsul/domain/recordFlavor/dto/RecordFlavorDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/recordFlavor/dto/RecordFlavorDto.java
@@ -1,0 +1,12 @@
+package com.depromeet.sulsul.domain.recordFlavor.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class RecordFlavorDto {
+    private String content;
+}

--- a/src/main/java/com/depromeet/sulsul/domain/recordFlavor/entity/RecordFlavor.java
+++ b/src/main/java/com/depromeet/sulsul/domain/recordFlavor/entity/RecordFlavor.java
@@ -1,0 +1,32 @@
+package com.depromeet.sulsul.domain.recordFlavor.entity;
+
+import com.depromeet.sulsul.domain.flavor.entity.Flavor;
+import com.depromeet.sulsul.domain.record.entity.Record;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecordFlavor {
+    @Id
+    @Column(name = "beer_flavor_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Record record;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "flavor_id")
+    private Flavor flavor;
+
+    public RecordFlavor(Long id, Record record, Flavor flavor) {
+        this.id = id;
+        this.record = record;
+        this.flavor = flavor;
+    }
+}

--- a/src/main/java/com/depromeet/sulsul/domain/recordFlavor/repository/RecordFlavorRepository.java
+++ b/src/main/java/com/depromeet/sulsul/domain/recordFlavor/repository/RecordFlavorRepository.java
@@ -1,0 +1,7 @@
+package com.depromeet.sulsul.domain.recordFlavor.repository;
+
+import com.depromeet.sulsul.domain.recordFlavor.entity.RecordFlavor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecordFlavorRepository extends JpaRepository<RecordFlavor, Long> {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,39 @@
+#server:
+#  port: 8082
+#
+#spring:
+#  config:
+#    activate:
+#      on-profile: dev
+#  jpa:
+#    database: mysql
+#    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+#    hibernate:
+#      ddl-auto: update
+#    properties:
+#      hibernate:
+#        show_sql: true
+#        format_sql: true
+#    open-in-view: false
+
 spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  datasource:
+    url: jdbc:h2:~/test-sulsul;
+    driverClassName: org.h2.Driver  # org.h2.Driver
+    username: sa
+    password:
   jpa:
-    database: mysql
-    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    #    database: mysql
+    #    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true
         format_sql: true
+        default_batch_fetch_size: 1000
     open-in-view: false


### PR DESCRIPTION
- Record와 관련 Flavor 정보 동시에 입력받아 저장
- Record와 관련 Flavor 정보 동시에 api로 전송

## 📍 주요 변경사항

<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 💡 중점적으로 봐주었으면 하는 부분

- yml파일 상에 H2 DB 적용 및 batch size적용
- batch size를 통한 데이터 검색
    - 이 방법이 과연 맞을까요...? 일단 최적화 방식은 일대다->일대다 호출로 1+1+1 으로 되어있습니다.
- Record Service상에서 여러 호출을 통해 값을 가져오는데, 코드가 많이 지저분하고 여기서 Record Flavor와 Flavor쪽에 접근하게 됩니다.
- 여러 문제들때문에...일단 구현에 중점을 두었는데 많은 부분에서 고쳐야 할 것 같아요... 

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->