### PR TITLE
카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'com.querydsl:querydsl-jpa'
     implementation 'com.querydsl:querydsl-apt'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'com.querydsl:querydsl-jpa'
     implementation 'com.querydsl:querydsl-apt'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  sulsuldb:
+    image: mariadb10.3:v1
+    container_name: sulsul-database
+    ports:
+      - "3306:3306"
+    volumes:
+      - ./database/:/var/lib/mysql
+    environment:
+      MYSQL_DATABASAE: sulsul
+      MYSQL_ROOT_PASSWORD: 1234
+      MYSQL_USER: minsoo
+      MYSQL_PASSWORD: 1234

--- a/src/main/java/com/depromeet/sulsul/config/SecurityConfig.java
+++ b/src/main/java/com/depromeet/sulsul/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package com.depromeet.sulsul.config;
+
+import com.depromeet.sulsul.oauth2.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+                .oauth2Login()
+                .userInfoEndpoint().userService(customOAuth2UserService);
+
+
+    }
+}

--- a/src/main/java/com/depromeet/sulsul/domain/member/dto/RoleType.java
+++ b/src/main/java/com/depromeet/sulsul/domain/member/dto/RoleType.java
@@ -1,0 +1,14 @@
+package com.depromeet.sulsul.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RoleType {
+
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String authority;
+}

--- a/src/main/java/com/depromeet/sulsul/domain/member/entity/Member.java
+++ b/src/main/java/com/depromeet/sulsul/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.depromeet.sulsul.domain.member.entity;
 
 import javax.persistence.*;
 
+import com.depromeet.sulsul.domain.member.dto.RoleType;
 import com.depromeet.sulsul.domain.record.entity.Record;
 import com.depromeet.sulsul.domain.review.entity.Review;
 import lombok.AccessLevel;
@@ -26,9 +27,15 @@ public class Member {
   @OneToMany(mappedBy = "member")
   private List<Review> reviews = new ArrayList<>();
 
+  @Enumerated(EnumType.STRING)
+  private RoleType role;
+
   private String email;
   private String name;
   private String profileUrl;
   private String phoneNumber;
 
+  public String getAuthority(){
+    return role.getAuthority();
+  }
 }

--- a/src/main/java/com/depromeet/sulsul/domain/member/entity/Member.java
+++ b/src/main/java/com/depromeet/sulsul/domain/member/entity/Member.java
@@ -1,23 +1,30 @@
 package com.depromeet.sulsul.domain.member.entity;
 
-import javax.persistence.*;
-
 import com.depromeet.sulsul.domain.member.dto.RoleType;
 import com.depromeet.sulsul.domain.record.entity.Record;
 import com.depromeet.sulsul.domain.review.entity.Review;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
-  @Id @Column(name = "member_id")
+  @Id
+  @Column(name = "member_id")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
@@ -35,7 +42,26 @@ public class Member {
   private String profileUrl;
   private String phoneNumber;
 
-  public String getAuthority(){
+  public String getAuthority() {
     return role.getAuthority();
+  }
+
+  @Builder
+  public Member(Long id, List<Record> records, List<Review> reviews, RoleType role, String email, String name,
+      String profileUrl, String phoneNumber) {
+    this.id = id;
+    this.records = records;
+    this.reviews = reviews;
+    this.role = role;
+    this.email = email;
+    this.name = name;
+    this.profileUrl = profileUrl;
+    this.phoneNumber = phoneNumber;
+  }
+
+  public Member update(String name, String email){
+    this.name = name;
+    this.email = email;
+    return this;
   }
 }

--- a/src/main/java/com/depromeet/sulsul/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/depromeet/sulsul/domain/member/repository/MemberRepository.java
@@ -1,8 +1,10 @@
 package com.depromeet.sulsul.domain.member.repository;
 
 import com.depromeet.sulsul.domain.member.entity.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom{
 
+  Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/depromeet/sulsul/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/depromeet/sulsul/oauth2/service/CustomOAuth2UserService.java
@@ -2,9 +2,10 @@ package com.depromeet.sulsul.oauth2.service;
 
 import com.depromeet.sulsul.domain.member.entity.Member;
 import com.depromeet.sulsul.domain.member.repository.MemberRepository;
+import java.util.Collections;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
@@ -13,39 +14,36 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
-
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
-    @Override
-    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+  private final MemberRepository memberRepository;
 
-        OAuth2UserService delegate = new DefaultOAuth2UserService();
-        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
-        // OAuth2 서비스 id (구글, 카카오, 네이버)
-        String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        String userNameAttributeName = userRequest.getClientRegistration()
-                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+    OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService = new DefaultOAuth2UserService();
+    OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
 
-        OAuthAttributes attributes = OAuthAttributes.
-                of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+    // OAuth2 서비스 id (구글, 카카오, 네이버)
+    String registrationId = userRequest.getClientRegistration().getRegistrationId();
+    String userNameAttributeName = userRequest.getClientRegistration()
+        .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
 
-        /*Member member = saveOrUpdate(attributes);*/
+    OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
 
-        return new DefaultOAuth2User(
-                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
-                attributes.getAttributes(),
-                attributes.getNameAttributeKey());
-    }
+    saveOrUpdate(attributes);
 
-    /*private Member saveOrUpdate(OAuthAttributes attributes) {
-        Member user = memberRepository.findByEmail(attributes.getEmail())
-                .map(entity -> entity.update(attributes.getName(),attributes.getPicture()))
-                .orElse(attributes.toEntity());
+    return new DefaultOAuth2User(
+        Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+        attributes.getAttributes(), attributes.getNameAttributeKey());
+  }
 
-        return userRepository.save(user);
-    }*/
-    }
+  private void saveOrUpdate(OAuthAttributes attributes) {
+    Member member = memberRepository.findByEmail(attributes.getEmail())
+        .map(entity -> entity.update(attributes.getName(), attributes.getEmail()))
+        .orElse(attributes.toEntity());
+    memberRepository.save(member);
+  }
+}

--- a/src/main/java/com/depromeet/sulsul/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/depromeet/sulsul/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,51 @@
+package com.depromeet.sulsul.oauth2.service;
+
+import com.depromeet.sulsul.domain.member.entity.Member;
+import com.depromeet.sulsul.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2UserService delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        // OAuth2 서비스 id (구글, 카카오, 네이버)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        OAuthAttributes attributes = OAuthAttributes.
+                of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+        /*Member member = saveOrUpdate(attributes);*/
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                attributes.getAttributes(),
+                attributes.getNameAttributeKey());
+    }
+
+    /*private Member saveOrUpdate(OAuthAttributes attributes) {
+        Member user = memberRepository.findByEmail(attributes.getEmail())
+                .map(entity -> entity.update(attributes.getName(),attributes.getPicture()))
+                .orElse(attributes.toEntity());
+
+        return userRepository.save(user);
+    }*/
+    }

--- a/src/main/java/com/depromeet/sulsul/oauth2/service/OAuthAttributes.java
+++ b/src/main/java/com/depromeet/sulsul/oauth2/service/OAuthAttributes.java
@@ -1,47 +1,63 @@
 package com.depromeet.sulsul.oauth2.service;
 
+import com.depromeet.sulsul.domain.member.dto.RoleType;
+import com.depromeet.sulsul.domain.member.entity.Member;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.util.Map;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class OAuthAttributes {
 
-    private static final String KAKAO = "kakao";
-    private static final String NAVER = "naver";
+  private static final String KAKAO = "kakao";
+  private static final String NAVER = "naver";
 
-    private Map<String, Object> attributes;
-    private String nameAttributeKey;
-    private String name;
-    private String email;
-    @Builder
-    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email) {
-        this.attributes = attributes;
-        this.nameAttributeKey = nameAttributeKey;
-        this.name = name;
-        this.email = email;
+  private Map<String, Object> attributes;
+  private String nameAttributeKey;
+  private String name;
+  private String email;
 
+  @Builder
+  public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email) {
+    this.attributes = attributes;
+    this.nameAttributeKey = nameAttributeKey;
+    this.name = name;
+    this.email = email;
+
+  }
+
+  public static OAuthAttributes of(String registrationId, String userNameAttributeName,
+      Map<String, Object> attributes) {
+    switch (registrationId) {
+      case KAKAO:
+        return ofKakao("id", attributes);
+      case NAVER:
+
+      default:
+        throw new IllegalArgumentException();
     }
+  }
 
-    public static  OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes){
-        switch (registrationId){
-            case KAKAO:
-                return ofKakao("id",attributes);
-            default:
-                throw new IllegalArgumentException();
-        }
-    }
+  private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
 
-    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes){
-        Map<String, Object> kakaoAccount = (Map<String,Object>) attributes.get("kakao_account");
+    Map<String, Object> response = (Map<String, Object>) attributes.get("kakao_account");
+    Map<String, Object> profile = (Map<String, Object>) response.get("profile");
 
-        kakaoAccount.forEach((k,v) -> System.out.println("k = " + k + " v " + v));
+    return OAuthAttributes.builder()
+        .name((String) profile.get("nickname"))
+        .email((String) response.get("email"))
+        .attributes(attributes)
+        .nameAttributeKey(userNameAttributeName)
+        .build();
+  }
 
-        return OAuthAttributes.builder()
-                .email((String) kakaoAccount.get("email"))
-                .attributes(attributes)
-                .nameAttributeKey(userNameAttributeName)
-                .build();
-    }
+  public Member toEntity() {
+    return Member.builder()
+        .name(name)
+        .email(email)
+        .role(RoleType.USER)
+        .build();
+  }
 }

--- a/src/main/java/com/depromeet/sulsul/oauth2/service/OAuthAttributes.java
+++ b/src/main/java/com/depromeet/sulsul/oauth2/service/OAuthAttributes.java
@@ -1,0 +1,47 @@
+package com.depromeet.sulsul.oauth2.service;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuthAttributes {
+
+    private static final String KAKAO = "kakao";
+    private static final String NAVER = "naver";
+
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+
+    }
+
+    public static  OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes){
+        switch (registrationId){
+            case KAKAO:
+                return ofKakao("id",attributes);
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes){
+        Map<String, Object> kakaoAccount = (Map<String,Object>) attributes.get("kakao_account");
+
+        kakaoAccount.forEach((k,v) -> System.out.println("k = " + k + " v " + v));
+
+        return OAuthAttributes.builder()
+                .email((String) kakaoAccount.get("email"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+}

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -8,7 +8,7 @@ spring:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true
@@ -20,12 +20,13 @@ spring:
         registration:
           kakao:
             client-id: 0c67e7fe975454e2ece8b6d77efe298d
-            client-secret: LUhFfkYc6I8UmAsMSU1aZfAs7GpAmjH2
-            scope: profile_nickname
+            scope:
+              - profile_nickname
+              - account_email
             redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+            client-authentication-method: POST
             authorization-grant-type: authorization_code
             client-name: kakao
-            client-authentication-method: POST
 
         provider:
           kakao:
@@ -33,3 +34,5 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+# kauth.kakao.com/oauth/authorize?client_id=0c67e7fe975454e2ece8b6d77efe298d&redirect_uri=http://localhost:8080/login/oauth2/code/kakao&response_type=code
+# http://localhost:8080/oauth2/authorization/kakao

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/sulsul?serverTimezone=Asia/Seoul
+    username: root
+    password: 1234
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    open-in-view: false

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -14,3 +14,22 @@ spring:
         show_sql: true
         format_sql: true
     open-in-view: false
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: 0c67e7fe975454e2ece8b6d77efe298d
+            client-secret: LUhFfkYc6I8UmAsMSU1aZfAs7GpAmjH2
+            scope: profile_nickname
+            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+            authorization-grant-type: authorization_code
+            client-name: kakao
+            client-authentication-method: POST
+
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id


### PR DESCRIPTION
## 📍 주요 변경사항

<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

카카오 로그인 구현

## 💡 중점적으로 봐주었으면 하는 부분

찬영님이 말씀하셨던 클라이언트 -> 서버 코드 전달 구조가 아닌

클라이언트에서 `http://localhost:8080/oauth2/authorization/kakao` 경로를 호출하면 카카오 인증을 받아 진행하는 형식으로
구현하였습니다. 확인해주시면 감사하겠습니다~

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->