### PR TITLE
작성 맥주 리스트 관련 API 및 기존 기록조회 API 수정

### DIFF
--- a/src/main/java/com/depromeet/sulsul/config/SecurityConfig.java
+++ b/src/main/java/com/depromeet/sulsul/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.depromeet.sulsul.oauth2.handler.CustomOAuth2SuccessHandler;
 import com.depromeet.sulsul.oauth2.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
@@ -15,18 +16,23 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
 
   @Override
+  public void configure(WebSecurity web) throws Exception {
+    web.ignoring().antMatchers("/h2-console/**");
+  }
+
+  @Override
   protected void configure(HttpSecurity http) throws Exception {
     http.csrf().disable()
         .authorizeHttpRequests()
-        .antMatchers("/swagger-ui.html", "/h2-console", "/**").permitAll()
-        .anyRequest().authenticated()
+          .antMatchers("/swagger-ui/*","/h2-console/**","/**").permitAll()
+          .anyRequest().authenticated()
         .and()
-        .logout()
-        .logoutSuccessUrl("/")
+          .logout()
+          .logoutSuccessUrl("/")
         .and()
-        .oauth2Login()
-        .userInfoEndpoint().userService(customOAuth2UserService)
+          .oauth2Login()
+          .userInfoEndpoint().userService(customOAuth2UserService)
         .and()
-        .successHandler(customOAuth2SuccessHandler);
+          .successHandler(customOAuth2SuccessHandler);
   }
 }

--- a/src/main/java/com/depromeet/sulsul/domain/flavor/controller/FlavorController.java
+++ b/src/main/java/com/depromeet/sulsul/domain/flavor/controller/FlavorController.java
@@ -26,9 +26,9 @@ public class FlavorController {
     public ResponseDto<List<FlavorResponse>> findAll() {
         return ResponseDto.from(flavorService.findAll());
     }
-  
-  @GetMapping("/{beerId}")
-  public List<FlavorResponseDto> test(@PathVariable("beerId") Long beerId){
-    return flavorService.findTopFlavors(beerId);
-  }
+
+    @GetMapping("/{beerId}")
+    public List<FlavorResponseDto> findTopFlavors(@PathVariable("beerId") Long beerId){
+      return flavorService.findTopFlavors(beerId);
+    }
 }

--- a/src/main/java/com/depromeet/sulsul/domain/flavor/controller/FlavorController.java
+++ b/src/main/java/com/depromeet/sulsul/domain/flavor/controller/FlavorController.java
@@ -6,6 +6,8 @@ import com.depromeet.sulsul.domain.flavor.dto.FlavorResponseDto;
 import com.depromeet.sulsul.domain.flavor.dto.FlavorResponse;
 import com.depromeet.sulsul.domain.flavor.entity.Flavor;
 import com.depromeet.sulsul.domain.flavor.service.FlavorService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,17 +20,20 @@ import java.util.List;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/flavors")
+@Api(tags = "맛 조회 API")
 public class FlavorController {
 
     private final FlavorService flavorService;
 
+    @ApiOperation(value = "전체 맛 조회 API")
     @GetMapping
     public ResponseDto<List<FlavorResponse>> findAll() {
         return ResponseDto.from(flavorService.findAll());
     }
 
+    @ApiOperation(value = "해당 맥주의 최상위 맛 3개 조회 API")
     @GetMapping("/{beerId}")
-    public List<FlavorResponseDto> findTopFlavors(@PathVariable("beerId") Long beerId){
-      return flavorService.findTopFlavors(beerId);
+    public ResponseDto<List<FlavorResponseDto>> findTopFlavors(@PathVariable("beerId") Long beerId){
+      return ResponseDto.from(flavorService.findTopFlavors(beerId));
     }
 }

--- a/src/main/java/com/depromeet/sulsul/domain/memberBeer/controller/MemberBeerController.java
+++ b/src/main/java/com/depromeet/sulsul/domain/memberBeer/controller/MemberBeerController.java
@@ -2,6 +2,8 @@ package com.depromeet.sulsul.domain.memberBeer.controller;
 
 import com.depromeet.sulsul.common.response.dto.ResponseDto;
 import com.depromeet.sulsul.domain.memberBeer.service.MemberBeerService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,16 +16,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/beer/heart")
+@Api(tags = "찜하기 관련 API")
 public class MemberBeerController {
 
   private final MemberBeerService memberBeerService;
 
   @PostMapping("/{beerId}")
+  @ApiOperation(value = "찜하기 API")
   public ResponseDto<Boolean> save(@PathVariable("beerId") Long beerId){
     Long memberId = 1L; // TODO : 임시 유저아이디 생성
     return ResponseDto.from(memberBeerService.save(beerId, memberId));
   }
 
+  @ApiOperation(value = "찜하기 취소 API")
   @DeleteMapping("/{beerId}")
   public ResponseDto<Boolean> delete(@PathVariable("beerId") Long beerId){
     Long memberId = 1L; // TODO : 임시 유저아이디 생성

--- a/src/main/java/com/depromeet/sulsul/domain/memberBeer/controller/MemberBeerController.java
+++ b/src/main/java/com/depromeet/sulsul/domain/memberBeer/controller/MemberBeerController.java
@@ -1,5 +1,6 @@
 package com.depromeet.sulsul.domain.memberBeer.controller;
 
+import com.depromeet.sulsul.common.response.dto.ResponseDto;
 import com.depromeet.sulsul.domain.memberBeer.service.MemberBeerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,15 +19,14 @@ public class MemberBeerController {
   private final MemberBeerService memberBeerService;
 
   @PostMapping("/{beerId}")
-  public ResponseEntity save(@PathVariable("beerId") Long beerId){
+  public ResponseDto<Boolean> save(@PathVariable("beerId") Long beerId){
     Long memberId = 1L; // TODO : 임시 유저아이디 생성
-    return memberBeerService.save(beerId, memberId) ? new ResponseEntity<>(HttpStatus.OK) : new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-
+    return ResponseDto.from(memberBeerService.save(beerId, memberId));
   }
 
   @DeleteMapping("/{beerId}")
-  public ResponseEntity delete(@PathVariable("beerId") Long beerId){
+  public ResponseDto<Boolean> delete(@PathVariable("beerId") Long beerId){
     Long memberId = 1L; // TODO : 임시 유저아이디 생성
-    return memberBeerService.delete(beerId, memberId) ? new ResponseEntity<>(HttpStatus.OK) : new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    return ResponseDto.from(memberBeerService.delete(beerId, memberId));
   }
 }

--- a/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
@@ -70,7 +70,7 @@ public class RecordController {
   }
 
   @ApiOperation(value = "기록 작성 맥주 티켓 조회 API")
-  @GetMapping(value = {"/ticket/{recordId}", "/ticket"})
+  @GetMapping(value = {"/tickets/{recordId}", "/ticket"})
   public PageableResponseDto<RecordTicketResponseDto> findAllRecordsTicketWithPageable(@PathVariable(name = "recordId", required = false) Long recordId) {
     // TODO : 임시 유저아이디 사용.
     Long memberId = 1L;

--- a/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
@@ -2,15 +2,18 @@ package com.depromeet.sulsul.domain.record.controller;
 
 import com.depromeet.sulsul.common.response.dto.PageableResponseDto;
 import com.depromeet.sulsul.common.response.dto.ResponseDto;
+import com.depromeet.sulsul.domain.record.dto.RecordCountryAndCountResponseDto;
 import com.depromeet.sulsul.domain.record.dto.RecordFindRequestDto;
 import com.depromeet.sulsul.domain.record.dto.RecordRequestDto;
 import com.depromeet.sulsul.domain.record.dto.RecordResponseDto;
+import com.depromeet.sulsul.domain.record.dto.RecordTicketResponseDto;
 import com.depromeet.sulsul.domain.record.entity.Record;
 import com.depromeet.sulsul.domain.record.service.RecordService;
 import com.depromeet.sulsul.domain.recordFlavor.dto.RecordFlavorRequest;
 import com.depromeet.sulsul.domain.recordFlavor.service.RecordFlavorService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,7 +35,7 @@ public class RecordController {
 //        return ResponseDto.of(recordService.uploadImage(multipartFile));
 //    }
 
-  @PostMapping("")
+  @PostMapping()
   public ResponseEntity<Object> save(@RequestBody RecordRequestDto recordRequestDto) {
     Long memberIdTemp = 1L;
     Record recordSave = recordService.save(recordRequestDto, memberIdTemp);
@@ -43,19 +46,21 @@ public class RecordController {
   }
 
   @ApiOperation(value = "'이 맥주는 어때요' 관련 맥주 정보 조회 API")
-  @PostMapping("find")
-  public ResponseDto<PageableResponseDto<RecordResponseDto>> findAllRecordsWithPageable(
+  @PostMapping("/find")
+  public PageableResponseDto<RecordResponseDto> findAllRecordsWithPageable(
       @RequestBody RecordFindRequestDto recordFindRequestDto) {
-    return ResponseDto.from(recordService.findAllRecordsWithPageable(recordFindRequestDto));
+    // TODO : 임시 유저아이디 사용.
+    Long memberId = 1L;
+    return recordService.findAllRecordsWithPageable(recordFindRequestDto, memberId);
   }
 
   @ApiOperation(value = "기록 삭제 API")
-  @DeleteMapping("")
-  public ResponseDto<Long> delete(@RequestParam Long recordId) {
+  @DeleteMapping("/{recordId}")
+  public ResponseDto<Long> delete(@PathVariable Long recordId) {
     // TODO : 임시 유저아이디 사용.
-    Long memberIdTemp = 1L;
-    recordService.delete(recordId, memberIdTemp);
-    return ResponseDto.from(recordService.delete(recordId, memberIdTemp));
+    Long memberId = 1L;
+    recordService.delete(recordId, memberId);
+    return ResponseDto.from(recordService.delete(recordId, memberId));
   }
 
   @ApiOperation(value = "유저별 기록 수 조회 API")
@@ -63,4 +68,20 @@ public class RecordController {
   public ResponseDto<Long> findMemberRecordCount(@PathVariable Long id){
    return ResponseDto.from(recordService.findRecordCountByMemberId(id));
   }
+
+  @ApiOperation(value = "기록 작성 맥주 티켓 조회 API")
+  @GetMapping(value = {"/ticket/{recordId}", "/ticket"})
+  public PageableResponseDto<RecordTicketResponseDto> findAllRecordsTicketWithPageable(@PathVariable(name = "recordId", required = false) Long recordId) {
+    // TODO : 임시 유저아이디 사용.
+    Long memberId = 1L;
+    return recordService.findAllRecordsTicketWithPageable(recordId, memberId);
+  }
+
+  @ApiOperation(value = "해당 유저 최신 작성 record 국가 개수 조회 API")
+  @GetMapping("/ticket/country/{recordId}")
+  public ResponseDto<RecordCountryAndCountResponseDto> findCountryAndCountByMemberId(){
+    Long memberId = 1L;
+    return ResponseDto.from(recordService.findCountryAndCountByMemberId(memberId));
+  }
+
 }

--- a/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
@@ -78,7 +78,7 @@ public class RecordController {
   }
 
   @ApiOperation(value = "해당 유저 최신 작성 record 국가 개수 조회 API")
-  @GetMapping("/ticket/country/{recordId}")
+  @GetMapping("/ticket/country/")
   public ResponseDto<RecordCountryAndCountResponseDto> findCountryAndCountByMemberId(){
     Long memberId = 1L;
     return ResponseDto.from(recordService.findCountryAndCountByMemberId(memberId));

--- a/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
@@ -46,11 +46,11 @@ public class RecordController {
   }
 
   @DeleteMapping("")
-  public ResponseEntity<Object> delete(@RequestParam Long recordId) {
+  public ResponseDto<Long> delete(@RequestParam Long recordId) {
     // TODO : 임시 유저아이디 사용.
     Long memberIdTemp = 1L;
     recordService.delete(recordId, memberIdTemp);
-    return new ResponseEntity<>(HttpStatus.OK);
+    return ResponseDto.from(recordService.delete(recordId, memberIdTemp));
   }
 
   @GetMapping("/count/{id}")

--- a/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
@@ -9,6 +9,8 @@ import com.depromeet.sulsul.domain.record.entity.Record;
 import com.depromeet.sulsul.domain.record.service.RecordService;
 import com.depromeet.sulsul.domain.recordFlavor.dto.RecordFlavorRequest;
 import com.depromeet.sulsul.domain.recordFlavor.service.RecordFlavorService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/records")
 @RequiredArgsConstructor
+@Api(tags = "맥주 기록 APIs")
 public class RecordController {
 
   private final RecordService recordService;
@@ -39,12 +42,14 @@ public class RecordController {
     return new ResponseEntity<>(HttpStatus.OK);
   }
 
+  @ApiOperation(value = "'이 맥주는 어때요' 관련 맥주 정보 조회 API")
   @PostMapping("find")
   public ResponseDto<PageableResponseDto<RecordResponseDto>> findAllRecordsWithPageable(
       @RequestBody RecordFindRequestDto recordFindRequestDto) {
     return ResponseDto.from(recordService.findAllRecordsWithPageable(recordFindRequestDto));
   }
 
+  @ApiOperation(value = "기록 삭제 API")
   @DeleteMapping("")
   public ResponseDto<Long> delete(@RequestParam Long recordId) {
     // TODO : 임시 유저아이디 사용.
@@ -53,6 +58,7 @@ public class RecordController {
     return ResponseDto.from(recordService.delete(recordId, memberIdTemp));
   }
 
+  @ApiOperation(value = "유저별 기록 수 조회 API")
   @GetMapping("/count/{id}")
   public ResponseDto<Long> findMemberRecordCount(@PathVariable Long id){
    return ResponseDto.from(recordService.findRecordCountByMemberId(id));

--- a/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordCountryAndCountResponseDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordCountryAndCountResponseDto.java
@@ -1,0 +1,19 @@
+package com.depromeet.sulsul.domain.record.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RecordCountryAndCountResponseDto {
+  String country;
+  Long count;
+
+  @QueryProjection
+  public RecordCountryAndCountResponseDto(String country, Long count) {
+    this.country = country;
+    this.count = count;
+  }
+}

--- a/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordFindRequestDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordFindRequestDto.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RecordFindRequestDto {
-
   private Long memberId;
   private Long beerId;
   private Long recordId;

--- a/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordFindRequestDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordFindRequestDto.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RecordFindRequestDto {
-  private Long memberId;
   private Long beerId;
   private Long recordId;
 }

--- a/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordTicketResponseDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordTicketResponseDto.java
@@ -1,0 +1,38 @@
+package com.depromeet.sulsul.domain.record.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RecordTicketResponseDto {
+  private Long recordId;
+  private String beerNameKor;
+  private String beerNameEng;
+  private LocalDateTime createdAt;
+  private Integer feel;
+  private String startCountryEng;
+  private String endCountryEng;
+  private String startCountryKor;
+  private String endCountryKor;
+
+  @QueryProjection
+  public RecordTicketResponseDto(Long recordId, String beerNameKor, String beerNameEng,
+      LocalDateTime createdAt, Integer feel, String startCountryEng, String endCountryEng,
+      String startCountryKor, String endCountryKor) {
+    this.recordId = recordId;
+    this.beerNameKor = beerNameKor;
+    this.beerNameEng = beerNameEng;
+    this.createdAt = createdAt;
+    this.feel = feel;
+    this.startCountryEng = startCountryEng;
+    this.endCountryEng = endCountryEng;
+    this.startCountryKor = startCountryKor;
+    this.endCountryKor = endCountryKor;
+  }
+
+}

--- a/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordTicketResponseDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordTicketResponseDto.java
@@ -11,14 +11,15 @@ import lombok.Setter;
 @NoArgsConstructor
 public class RecordTicketResponseDto {
   private Long recordId;
-  private String beerNameKor;
-  private String beerNameEng;
-  private LocalDateTime createdAt;
   private Integer feel;
   private String startCountryEng;
   private String endCountryEng;
   private String startCountryKor;
   private String endCountryKor;
+  private LocalDateTime createdAt;
+
+  private String beerNameKor;
+  private String beerNameEng;
 
   @QueryProjection
   public RecordTicketResponseDto(Long recordId, String beerNameKor, String beerNameEng,

--- a/src/main/java/com/depromeet/sulsul/domain/record/entity/Record.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/entity/Record.java
@@ -25,7 +25,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-
 @Entity
 @Getter
 @Builder
@@ -48,29 +47,54 @@ public class Record extends BaseEntity {
   @JoinColumn(name = "beer_id")
   private Beer beer;
 
-  @OneToMany(fetch = FetchType.LAZY, mappedBy = "record")
+  @OneToMany(mappedBy = "record")
   private final List<RecordFlavor> recordFlavors = new ArrayList<>();
 
   private String content;
   private Boolean isPublic;
   private Integer feel;
-  private Integer score;
+  private String startCountryKor;
+  private String startCountryEng;
+  private String endCountryKor;
+  private String endCountryEng;
+  private String imageUrl;
+
   @Builder
-  public Record(String content, Boolean isPublic, Integer feel, Integer score) {
-    this.content = content;
-    this.isPublic = isPublic;
-    this.feel = feel;
-    this.score = score;
-  }
-  public void updateBeer(Beer beer) {
-    this.beer = beer;
-  }
+  public Record(String content, Boolean isPublic, Integer feel) {
+      this.content = content;
+      this.isPublic = isPublic;
+      this.feel = feel;
+    }
 
   public Record(Member member, Beer beer, RecordRequestDto recordRequestDto) {
-    this.member = member;
+      this.member = member;
+      this.beer = beer;
+      this.content = recordRequestDto.getContent();
+      this.isPublic = recordRequestDto.getIsPublic();
+      this.feel = recordRequestDto.getFeel();
+  }
+
+  public void updateStartCountry(Record record) {
+    if (record != null) {
+      this.startCountryKor = record.getStartCountryKor();
+      this.startCountryEng = record.getStartCountryEng();
+      return;
+    }
+    this.startCountryKor = "한국";
+    this.startCountryEng = "Korea";
+  }
+
+  public void updateEndCountry(Beer beer) {
+    if (beer != null) {
+      this.endCountryKor = beer.getCountry().getNameKor();
+      this.endCountryEng = beer.getCountry().getNameEng();
+      return;
+    }
+    this.endCountryKor = "한국";
+    this.endCountryEng = "Korea";
+  }
+
+  public void updateBeer(Beer beer) {
     this.beer = beer;
-    this.content = recordRequestDto.getContent();
-    this.isPublic = recordRequestDto.getIsPublic();
-    this.feel = recordRequestDto.getFeel();
   }
 }

--- a/src/main/java/com/depromeet/sulsul/domain/record/repository/RecordRepositoryCustom.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/repository/RecordRepositoryCustom.java
@@ -1,14 +1,20 @@
 package com.depromeet.sulsul.domain.record.repository;
 
+import com.depromeet.sulsul.domain.record.dto.RecordCountryAndCountResponseDto;
 import com.depromeet.sulsul.domain.record.dto.RecordFindRequestDto;
+import com.depromeet.sulsul.domain.record.dto.RecordTicketResponseDto;
 import com.depromeet.sulsul.domain.record.entity.Record;
 import java.util.List;
 import org.springframework.stereotype.Repository;
 
-@Repository
 public interface RecordRepositoryCustom {
 
-  List<Record> findAllRecordsWithPageable(RecordFindRequestDto recordFindRequestDto);
+  List<Record> findAllRecordsWithPageable(RecordFindRequestDto recordFindRequestDto, Long memberId);
 
-    Long findRecordCountByMemberId(Long id);
+  Long findRecordCountByMemberId(Long id);
+
+  List<RecordTicketResponseDto> findAllRecordsTicketWithPageable(Long beerId, Long memberId);
+
+  RecordCountryAndCountResponseDto findRecordCountryAndCountResponseDto(Long memberId);
+
 }

--- a/src/main/java/com/depromeet/sulsul/domain/record/repository/RecordRepositoryCustomImpl.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/repository/RecordRepositoryCustomImpl.java
@@ -5,28 +5,30 @@ import static com.depromeet.sulsul.domain.member.entity.QMember.member;
 import static com.depromeet.sulsul.domain.record.entity.QRecord.record;
 
 import com.depromeet.sulsul.domain.member.entity.QMember;
+import com.depromeet.sulsul.domain.record.dto.QRecordCountryAndCountResponseDto;
+import com.depromeet.sulsul.domain.record.dto.QRecordTicketResponseDto;
+import com.depromeet.sulsul.domain.record.dto.RecordCountryAndCountResponseDto;
 import com.depromeet.sulsul.domain.record.dto.RecordFindRequestDto;
+import com.depromeet.sulsul.domain.record.dto.RecordTicketResponseDto;
 import com.depromeet.sulsul.domain.record.entity.Record;
 import com.depromeet.sulsul.util.PaginationUtil;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import javax.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 public class RecordRepositoryCustomImpl implements RecordRepositoryCustom {
 
   private final JPAQueryFactory queryFactory;
 
-  public RecordRepositoryCustomImpl(EntityManager entityManager) {
-    this.queryFactory = new JPAQueryFactory(entityManager);
-  }
-
   @Override
-  public List<Record> findAllRecordsWithPageable(RecordFindRequestDto recordFindRequestDto) {
+  public List<Record> findAllRecordsWithPageable(RecordFindRequestDto recordFindRequestDto, Long memberId) {
     return queryFactory.select(record)
         .from(record)
         .where(beerIdEq(recordFindRequestDto.getBeerId())
-            , memberIdEq(recordFindRequestDto.getMemberId())
+            , memberIdEq(memberId)
             , recordIdGoe(recordFindRequestDto.getRecordId())
             , record.deletedAt.isNull()
         )
@@ -44,6 +46,36 @@ public class RecordRepositoryCustomImpl implements RecordRepositoryCustom {
             .count();
   }
 
+  @Override
+  public List<RecordTicketResponseDto> findAllRecordsTicketWithPageable(Long recordId, Long memberId) {
+    return queryFactory.select(new QRecordTicketResponseDto(
+            record.id, record.beer.nameKor, record.beer.nameEng, record.createdAt, record.feel
+            , record.startCountryEng, record.endCountryEng, record.startCountryKor, record.endCountryKor
+        )).from(record)
+        .where(
+            memberIdEq(memberId)
+            , recordIdGoe(recordId)
+            , record.deletedAt.isNull()
+        )
+        .limit(PaginationUtil.PAGINATION_SIZE + 1)
+        .fetch();
+  }
+
+  @Override
+  public RecordCountryAndCountResponseDto findRecordCountryAndCountResponseDto(Long memberId){
+    return queryFactory.select(new QRecordCountryAndCountResponseDto(record.endCountryEng, record.count()))
+        .from(record)
+        .where(
+            record.endCountryEng.eq(
+                queryFactory.select(record.endCountryEng)
+                    .from(record)
+                    .orderBy(record.createdAt.desc())
+                    .fetchFirst()
+            )
+        )
+        .fetchOne();
+  }
+
   private BooleanExpression beerIdEq(Long beerId) {
     return beerId != null ? record.beer.id.eq(beerId) : null;
   }
@@ -55,4 +87,5 @@ public class RecordRepositoryCustomImpl implements RecordRepositoryCustom {
   private BooleanExpression recordIdGoe(Long recordId) {
     return recordId != null ? record.id.goe(recordId) : null;
   }
+
 }

--- a/src/main/java/com/depromeet/sulsul/domain/record/service/RecordService.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/service/RecordService.java
@@ -83,9 +83,10 @@ public class RecordService {
 
   // Todo : 로그인 구현 이후 유저 validation 로직 추가 예정
   @Transactional
-  public void delete(Long recordId, Long memberId) {
+  public Long delete(Long recordId, Long memberId) {
     Record targetRecord = recordRepository.getById(recordId);
     targetRecord.delete();
+    return recordId;
   }
 
   public Long findRecordCountByMemberId(Long id) {

--- a/src/main/java/com/depromeet/sulsul/domain/record/service/RecordService.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/service/RecordService.java
@@ -11,9 +11,11 @@ import com.depromeet.sulsul.domain.flavor.dto.FlavorDto;
 import com.depromeet.sulsul.domain.member.dto.MemberRecordDto;
 import com.depromeet.sulsul.domain.member.entity.Member;
 import com.depromeet.sulsul.domain.member.repository.MemberRepository;
+import com.depromeet.sulsul.domain.record.dto.RecordCountryAndCountResponseDto;
 import com.depromeet.sulsul.domain.record.dto.RecordFindRequestDto;
 import com.depromeet.sulsul.domain.record.dto.RecordRequestDto;
 import com.depromeet.sulsul.domain.record.dto.RecordResponseDto;
+import com.depromeet.sulsul.domain.record.dto.RecordTicketResponseDto;
 import com.depromeet.sulsul.domain.record.entity.Record;
 import com.depromeet.sulsul.domain.record.repository.RecordRepository;
 import com.depromeet.sulsul.domain.recordFlavor.entity.RecordFlavor;
@@ -53,11 +55,11 @@ public class RecordService {
   }
 
   public PageableResponseDto<RecordResponseDto> findAllRecordsWithPageable(
-      RecordFindRequestDto recordFindRequestDto) {
+      RecordFindRequestDto recordFindRequestDto, Long memberId) {
     List<Record> allRecordWithPageable = recordRepository.findAllRecordsWithPageable(
-        recordFindRequestDto);
+        recordFindRequestDto, memberId);
     List<RecordResponseDto> allRecordDtosWithPageableResponse = new ArrayList<>();
-    PageableResponseDto<RecordResponseDto> recordDtoPageableResponse = new PageableResponseDto<>();
+//    PageableResponseDto<RecordResponseDto> recordDtoPageableResponse = new PageableResponseDto<>();
 
     for (Record record : allRecordWithPageable) {
       List<RecordFlavor> recordFlavors = record.getRecordFlavors();
@@ -73,12 +75,11 @@ public class RecordService {
           new RecordResponseDto(record.getContent(), memberRecordDto,
               record.getFeel(), flavorDtos, record.getCreatedAt(), record.getUpdatedAt()));
     }
-    if (isOverPaginationSize(allRecordDtosWithPageableResponse)) {
-      allRecordDtosWithPageableResponse.remove(PAGINATION_SIZE);
-      recordDtoPageableResponse.setHasNext(true);
-    }
-    recordDtoPageableResponse.setContents(allRecordDtosWithPageableResponse);
-    return recordDtoPageableResponse;
+//    if (isOverPaginationSize(allRecordDtosWithPageableResponse)) {
+//      allRecordDtosWithPageableResponse.remove(PAGINATION_SIZE);
+//      recordDtoPageableResponse.setHasNext(true);
+//    }
+    return PageableResponseDto.of(allRecordDtosWithPageableResponse, recordFindRequestDto.getRecordId(), PAGINATION_SIZE);
   }
 
   // Todo : 로그인 구현 이후 유저 validation 로직 추가 예정
@@ -91,5 +92,14 @@ public class RecordService {
 
   public Long findRecordCountByMemberId(Long id) {
     return recordRepository.findRecordCountByMemberId(id);
+  }
+
+  public PageableResponseDto<RecordTicketResponseDto> findAllRecordsTicketWithPageable(Long recordId, Long memberId){
+    List<RecordTicketResponseDto> allRecordsTicketWithPageable = recordRepository.findAllRecordsTicketWithPageable(recordId, memberId);
+    return PageableResponseDto.of(allRecordsTicketWithPageable, recordId, PAGINATION_SIZE);
+  }
+
+  public RecordCountryAndCountResponseDto findCountryAndCountByMemberId(Long memberId){
+    return recordRepository.findRecordCountryAndCountResponseDto(memberId);
   }
 }


### PR DESCRIPTION
## 📍 주요 변경사항

- [맥주 작성 리스트](https://www.notion.so/depromeet/record-API-b1995742720546bb91ab8bd7dcbc670a) 조회 API생성
- [최신 작성 record 국가 및 티켓수](https://www.notion.so/depromeet/record-API-09dd28bbb7224990bb72bcf8344284d1) 조회 API생성
- 맥주 상세 정보 관련 input data 변경 및 responseDTO 내용 일부 수정

<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 💡 중점적으로 봐주었으면 하는 부분
- 맥주 작성 리스트와 최신 작성 record의 경우 동일한 페이지에서 불려오지만, 작성 리스트의 경우 페이징을 위해 여러번 호출하기도 하고 둘의 내용이 많이 달라 따로 api를 구성하였습니다.
- PageableResponseDto의 경우 마지막에 가져온 id를 통해 cursor를 세팅했습니다.

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->