### PR TITLE
✨ 맥주 record 업데이트/조회 기능 추가 등

### DIFF
--- a/src/main/java/com/depromeet/sulsul/common/error/dto/ErrorType.java
+++ b/src/main/java/com/depromeet/sulsul/common/error/dto/ErrorType.java
@@ -11,6 +11,7 @@ public enum ErrorType {
   MEMBER_NOT_FOUND("일치하는 회원정보가 없습니다."),
   FLAVOR_NOT_FOUND("일치하는 맛 정보가 없습니다."),
   RECORD_NOT_FOUND("일치하는 기록 정보가 없습니다."),
+  MEMBER_LEVEL_NOT_FOUND("일치하는 멤버 래밸 정보가 없습니다."),
   UNEXPECTED_ERROR("예상치 못한 에러가 발생했습니다.");
 
   private final String message;

--- a/src/main/java/com/depromeet/sulsul/common/error/dto/ErrorType.java
+++ b/src/main/java/com/depromeet/sulsul/common/error/dto/ErrorType.java
@@ -10,6 +10,7 @@ public enum ErrorType {
   BEER_NOT_FOUND("일치하는 맥주정보가 없습니다."),
   MEMBER_NOT_FOUND("일치하는 회원정보가 없습니다."),
   FLAVOR_NOT_FOUND("일치하는 맛 정보가 없습니다."),
+  RECORD_NOT_FOUND("일치하는 기록 정보가 없습니다."),
   UNEXPECTED_ERROR("예상치 못한 에러가 발생했습니다.");
 
   private final String message;

--- a/src/main/java/com/depromeet/sulsul/common/error/exception/custom/MemberLevelNotFoundException.java
+++ b/src/main/java/com/depromeet/sulsul/common/error/exception/custom/MemberLevelNotFoundException.java
@@ -1,0 +1,8 @@
+package com.depromeet.sulsul.common.error.exception.custom;
+
+import static com.depromeet.sulsul.common.error.dto.ErrorType.MEMBER_LEVEL_NOT_FOUND;
+import com.depromeet.sulsul.common.error.exception.BusinessException;
+
+public class MemberLevelNotFoundException extends BusinessException {
+  public MemberLevelNotFoundException(){ super(MEMBER_LEVEL_NOT_FOUND.getMessage());}
+}

--- a/src/main/java/com/depromeet/sulsul/common/error/exception/custom/RecordNotFoundException.java
+++ b/src/main/java/com/depromeet/sulsul/common/error/exception/custom/RecordNotFoundException.java
@@ -1,0 +1,11 @@
+package com.depromeet.sulsul.common.error.exception.custom;
+
+import com.depromeet.sulsul.common.error.exception.BusinessException;
+
+import static com.depromeet.sulsul.common.error.dto.ErrorType.RECORD_NOT_FOUND;
+public class RecordNotFoundException extends BusinessException {
+  public RecordNotFoundException() {
+    super(RECORD_NOT_FOUND.getMessage());
+  }
+
+}

--- a/src/main/java/com/depromeet/sulsul/domain/memberLevel/controller/MemberLevelController.java
+++ b/src/main/java/com/depromeet/sulsul/domain/memberLevel/controller/MemberLevelController.java
@@ -1,0 +1,35 @@
+package com.depromeet.sulsul.domain.memberLevel.controller;
+
+import com.depromeet.sulsul.common.response.dto.ResponseDto;
+import com.depromeet.sulsul.domain.memberLevel.dto.MemberLevelResponseDto;
+import com.depromeet.sulsul.domain.memberLevel.entity.MemberLevel;
+import com.depromeet.sulsul.domain.memberLevel.service.MemberLevelService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/memberLevels")
+@Api(tags = "멤버 레밸 관련 API")
+@RequiredArgsConstructor
+public class MemberLevelController {
+  private final MemberLevelService memberLevelService;
+
+  @ApiOperation(value = "전체 level 정보 조회 API")
+  @GetMapping("/all")
+  public ResponseDto<List<MemberLevelResponseDto>> findAll(){
+    return ResponseDto.from(memberLevelService.findAll());
+  }
+
+  @ApiOperation(value = "기록수에 따른 level 조회 API")
+  @GetMapping("/{count}")
+  public ResponseDto<MemberLevelResponseDto> findMemberLevelByCount(@PathVariable Long count){
+    return ResponseDto.from(memberLevelService.findMemberLevelByCount(count));
+  }
+
+}

--- a/src/main/java/com/depromeet/sulsul/domain/memberLevel/dto/MemberLevelResponseDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/memberLevel/dto/MemberLevelResponseDto.java
@@ -1,0 +1,36 @@
+package com.depromeet.sulsul.domain.memberLevel.dto;
+
+import com.depromeet.sulsul.domain.memberLevel.entity.MemberLevel;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+public class MemberLevelResponseDto {
+  private Long id;
+  private String tier;
+  private String imageUrl;
+  private Integer req;
+
+  @QueryProjection
+  public MemberLevelResponseDto(Long id, String tier, String imageUrl, Integer req) {
+    this.id = id;
+    this.tier = tier;
+    this.imageUrl = imageUrl;
+    this.req = req;
+  }
+
+  public MemberLevel toEntity(){
+    return MemberLevel.builder()
+        .id(id)
+        .tier(tier)
+        .imageUrl(imageUrl)
+        .req(req)
+        .build();
+  }
+}

--- a/src/main/java/com/depromeet/sulsul/domain/memberLevel/entity/MemberLevel.java
+++ b/src/main/java/com/depromeet/sulsul/domain/memberLevel/entity/MemberLevel.java
@@ -35,6 +35,7 @@ public class MemberLevel {
 
   public static MemberLevelResponseDto toDto(MemberLevel memberLevel){
     return MemberLevelResponseDto.builder()
+        .id(memberLevel.getId())
         .tier(memberLevel.getTier())
         .imageUrl(memberLevel.getImageUrl())
         .req(memberLevel.req)

--- a/src/main/java/com/depromeet/sulsul/domain/memberLevel/entity/MemberLevel.java
+++ b/src/main/java/com/depromeet/sulsul/domain/memberLevel/entity/MemberLevel.java
@@ -1,0 +1,43 @@
+package com.depromeet.sulsul.domain.memberLevel.entity;
+
+import com.depromeet.sulsul.domain.member.entity.Member;
+import com.depromeet.sulsul.domain.memberLevel.dto.MemberLevelResponseDto;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@ToString
+@Builder
+public class MemberLevel {
+  @Id
+  @Column(name = "member_level_id")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  private String tier;
+  private String imageUrl;
+  private Integer req;
+
+  public static MemberLevelResponseDto toDto(MemberLevel memberLevel){
+    return MemberLevelResponseDto.builder()
+        .tier(memberLevel.getTier())
+        .imageUrl(memberLevel.getImageUrl())
+        .req(memberLevel.req)
+        .build();
+  }
+}

--- a/src/main/java/com/depromeet/sulsul/domain/memberLevel/repository/MemberLevelRepository.java
+++ b/src/main/java/com/depromeet/sulsul/domain/memberLevel/repository/MemberLevelRepository.java
@@ -1,0 +1,9 @@
+package com.depromeet.sulsul.domain.memberLevel.repository;
+
+import com.depromeet.sulsul.domain.memberLevel.entity.MemberLevel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+
+public interface MemberLevelRepository extends JpaRepository<MemberLevel, Long>, MemberLevelRepositoryCustom,
+    QuerydslPredicateExecutor<MemberLevel> {
+}

--- a/src/main/java/com/depromeet/sulsul/domain/memberLevel/repository/MemberLevelRepositoryCustom.java
+++ b/src/main/java/com/depromeet/sulsul/domain/memberLevel/repository/MemberLevelRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.depromeet.sulsul.domain.memberLevel.repository;
+
+import com.depromeet.sulsul.domain.memberLevel.dto.MemberLevelResponseDto;
+
+public interface MemberLevelRepositoryCustom {
+
+  MemberLevelResponseDto findMemberLevelByCount(Long count);
+
+}

--- a/src/main/java/com/depromeet/sulsul/domain/memberLevel/repository/MemberLevelRepositoryCustomImpl.java
+++ b/src/main/java/com/depromeet/sulsul/domain/memberLevel/repository/MemberLevelRepositoryCustomImpl.java
@@ -1,0 +1,24 @@
+package com.depromeet.sulsul.domain.memberLevel.repository;
+
+import static com.depromeet.sulsul.domain.memberLevel.entity.QMemberLevel.memberLevel;
+
+import com.depromeet.sulsul.domain.memberLevel.dto.MemberLevelResponseDto;
+import com.depromeet.sulsul.domain.memberLevel.dto.QMemberLevelResponseDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MemberLevelRepositoryCustomImpl implements MemberLevelRepositoryCustom {
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public MemberLevelResponseDto findMemberLevelByCount(Long count){
+    return queryFactory.select(new QMemberLevelResponseDto(
+          memberLevel.id, memberLevel.tier, memberLevel.imageUrl, memberLevel.req
+        ))
+        .from(memberLevel)
+        .where(memberLevel.req.loe(count))
+        .orderBy(memberLevel.req.desc())
+        .fetchFirst();
+  }
+}

--- a/src/main/java/com/depromeet/sulsul/domain/memberLevel/service/MemberLevelService.java
+++ b/src/main/java/com/depromeet/sulsul/domain/memberLevel/service/MemberLevelService.java
@@ -1,0 +1,29 @@
+package com.depromeet.sulsul.domain.memberLevel.service;
+
+import com.depromeet.sulsul.common.error.exception.custom.MemberLevelNotFoundException;
+import com.depromeet.sulsul.domain.memberLevel.dto.MemberLevelResponseDto;
+import com.depromeet.sulsul.domain.memberLevel.entity.MemberLevel;
+import com.depromeet.sulsul.domain.memberLevel.repository.MemberLevelRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class MemberLevelService {
+  private final MemberLevelRepository memberLevelRepository;
+
+  @Transactional(readOnly = true)
+  public List<MemberLevelResponseDto> findAll() {
+    return  memberLevelRepository.findAll().stream().map(MemberLevel::toDto).collect(Collectors.toList());
+  }
+
+  @Transactional(readOnly = true)
+  public MemberLevelResponseDto findMemberLevelByCount(Long memberId){
+    return memberLevelRepository.findMemberLevelByCount(memberId);
+  }
+
+}

--- a/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
@@ -8,6 +8,7 @@ import com.depromeet.sulsul.domain.record.dto.RecordFindRequestDto;
 import com.depromeet.sulsul.domain.record.dto.RecordRequestDto;
 import com.depromeet.sulsul.domain.record.dto.RecordResponseDto;
 import com.depromeet.sulsul.domain.record.dto.RecordTicketResponseDto;
+import com.depromeet.sulsul.domain.record.dto.RecordUpdateRequestDto;
 import com.depromeet.sulsul.domain.record.entity.Record;
 import com.depromeet.sulsul.domain.record.service.RecordService;
 import com.depromeet.sulsul.domain.recordFlavor.dto.RecordFlavorRequest;
@@ -18,6 +19,7 @@ import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,9 +42,35 @@ public class RecordController {
     return ResponseDto.from(recordService.uploadImage(multipartFile));
   }
 
+  @ApiOperation(value = "기록 작성 API")
   @PostMapping
   public ResponseDto<RecordResponseDto> save(@RequestBody RecordRequestDto recordRequestDto) {
     return ResponseDto.from(recordService.save(recordRequestDto));
+  }
+
+  @ApiOperation(value = "작성 기록 상세보기 API")
+  @GetMapping("/{recordId}")
+  public ResponseDto<RecordResponseDto> find(@PathVariable(name = "recordId", required = false) Long recordId) {
+    // TODO : 임시 유저아이디 사용.
+    Long memberId = 1L;
+    return ResponseDto.from(recordService.find(recordId, memberId));
+  }
+
+  @ApiOperation(value = "기록 업데이트 API")
+  @PatchMapping("/{recordId}")
+  public ResponseDto<RecordResponseDto> update(@RequestBody RecordUpdateRequestDto recordUpdateRequestDto) {
+    // TODO : 임시 유저아이디 사용.
+    Long memberId = 1L;
+    return ResponseDto.from(recordService.update(recordUpdateRequestDto, memberId));
+  }
+
+  @ApiOperation(value = "기록 삭제 API")
+  @DeleteMapping("/{recordId}")
+  public ResponseDto<Long> delete(@PathVariable Long recordId) {
+    // TODO : 임시 유저아이디 사용.
+    Long memberId = 1L;
+    recordService.delete(recordId, memberId);
+    return ResponseDto.from(recordService.delete(recordId, memberId));
   }
 
   @ApiOperation(value = "'이 맥주는 어때요' 관련 맥주 정보 조회 API")
@@ -54,14 +82,6 @@ public class RecordController {
     return recordService.findAllRecordsWithPageable(recordFindRequestDto, memberId);
   }
 
-  @ApiOperation(value = "기록 삭제 API")
-  @DeleteMapping("/{recordId}")
-  public ResponseDto<Long> delete(@PathVariable Long recordId) {
-    // TODO : 임시 유저아이디 사용.
-    Long memberId = 1L;
-    recordService.delete(recordId, memberId);
-    return ResponseDto.from(recordService.delete(recordId, memberId));
-  }
 
   @ApiOperation(value = "유저별 기록 수 조회 API")
   @GetMapping("/count/{id}")

--- a/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/controller/RecordController.java
@@ -45,7 +45,9 @@ public class RecordController {
   @ApiOperation(value = "기록 작성 API")
   @PostMapping
   public ResponseDto<RecordResponseDto> save(@RequestBody RecordRequestDto recordRequestDto) {
-    return ResponseDto.from(recordService.save(recordRequestDto));
+    // TODO : 임시 유저아이디 사용.
+    Long memberId = 1L;
+    return ResponseDto.from(recordService.save(recordRequestDto, memberId));
   }
 
   @ApiOperation(value = "작성 기록 상세보기 API")

--- a/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordRequestDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordRequestDto.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class RecordRequestDto {
 
-  private Long memberId;
   private Long beerId;
   private String imageUrl;
   private String content;

--- a/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordResponseDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordResponseDto.java
@@ -1,6 +1,7 @@
 package com.depromeet.sulsul.domain.record.dto;
 
 import com.depromeet.sulsul.domain.beer.dto.BeerResponseDto;
+import com.depromeet.sulsul.domain.beer.entity.Beer;
 import com.depromeet.sulsul.domain.flavor.dto.FlavorDto;
 import com.depromeet.sulsul.domain.member.dto.MemberRecordDto;
 import com.depromeet.sulsul.domain.record.entity.Record;
@@ -72,15 +73,23 @@ public class RecordResponseDto {
         .build();
   }
 
-  public void updateFlavors(List<FlavorDto> flavorDtos) {
+  public static RecordResponseDto createRecordResponseDto(Record record, Beer beer, List<FlavorDto> flavorDtos, Long recordCount){
+    RecordResponseDto recordResponseDto = RecordResponseDto.toDto(record);
+    recordResponseDto.updateBeerResponseDto(Beer.toDto(beer));
+    recordResponseDto.updateFlavors(flavorDtos);
+    recordResponseDto.updateRecordCount(recordCount);
+    return recordResponseDto;
+  }
+
+  private void updateFlavors(List<FlavorDto> flavorDtos) {
     this.flavorDtos = flavorDtos;
   }
 
-  public void updateRecordCount(Long recordCount) {
+  private void updateRecordCount(Long recordCount) {
     this.recordCount = recordCount;
   }
 
-  public void updateBeerResponseDto(BeerResponseDto beerResponseDto) {
+  private void updateBeerResponseDto(BeerResponseDto beerResponseDto) {
     this.beerResponseDto = beerResponseDto;
   }
 }

--- a/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordUpdateRequestDto.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/dto/RecordUpdateRequestDto.java
@@ -1,0 +1,30 @@
+package com.depromeet.sulsul.domain.record.dto;
+
+import com.depromeet.sulsul.domain.record.entity.Record;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RecordUpdateRequestDto {
+  private Long recordId;
+  private String imageUrl;
+  private String content;
+  private List<Long> FlavorIds = new ArrayList<>();
+  private Boolean isPublic;
+  private Integer feel;
+
+  public Record toEntity() {
+    return Record.builder()
+        .content(this.content)
+        .feel(this.feel)
+        .imageUrl(this.imageUrl)
+        .isPublic(this.isPublic)
+        .build();
+  }
+}

--- a/src/main/java/com/depromeet/sulsul/domain/record/entity/Record.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/entity/Record.java
@@ -4,9 +4,11 @@ import com.depromeet.sulsul.common.entity.BaseEntity;
 import com.depromeet.sulsul.domain.beer.entity.Beer;
 import com.depromeet.sulsul.domain.member.entity.Member;
 import com.depromeet.sulsul.domain.record.dto.RecordRequestDto;
+import com.depromeet.sulsul.domain.record.dto.RecordUpdateRequestDto;
 import com.depromeet.sulsul.domain.recordFlavor.entity.RecordFlavor;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -47,7 +49,7 @@ public class Record extends BaseEntity {
   private Beer beer;
 
   @OneToMany(mappedBy = "record")
-  private final List<RecordFlavor> recordFlavors = new ArrayList<>();
+  private List<RecordFlavor> recordFlavors = new ArrayList<>();
 
   private String content;
   private Boolean isPublic;
@@ -95,6 +97,19 @@ public class Record extends BaseEntity {
 
   public void updateBeer(Beer beer) {
     this.beer = beer;
+  }
+
+  public void updateRecord(RecordUpdateRequestDto recordUpdateRequestDto, List<RecordFlavor> recordFlavors){
+    if(recordUpdateRequestDto.getIsPublic() != null)
+      this.isPublic = recordUpdateRequestDto.getIsPublic();
+    if(recordUpdateRequestDto.getContent() != null)
+      this.content = recordUpdateRequestDto.getContent();
+    if(recordUpdateRequestDto.getFeel() != null)
+      this.feel = recordUpdateRequestDto.getFeel();
+    if(recordUpdateRequestDto.getImageUrl() != null)
+      this.imageUrl = recordUpdateRequestDto.getImageUrl();
+    if(recordFlavors != null)
+      this.recordFlavors = recordFlavors;
   }
 
 }

--- a/src/main/java/com/depromeet/sulsul/domain/record/entity/Record.java
+++ b/src/main/java/com/depromeet/sulsul/domain/record/entity/Record.java
@@ -75,7 +75,7 @@ public class Record extends BaseEntity {
     this.feel = recordRequestDto.getFeel();
   }
 
-  public void updateStartCountry(Record record) {
+  private void updateStartCountry(Record record) {
     if (record != null) {
       this.startCountryKor = record.getStartCountryKor();
       this.startCountryEng = record.getStartCountryEng();
@@ -84,8 +84,8 @@ public class Record extends BaseEntity {
     this.startCountryKor = "한국";
     this.startCountryEng = "Korea";
   }
-  
-  public void updateEndCountry(Beer beer) {
+
+  private void updateEndCountry(Beer beer) {
     if (beer != null) {
       this.endCountryKor = beer.getCountry().getNameKor();
       this.endCountryEng = beer.getCountry().getNameEng();
@@ -95,8 +95,17 @@ public class Record extends BaseEntity {
     this.endCountryEng = "Korea";
   }
 
-  public void updateBeer(Beer beer) {
+  private void updateBeer(Beer beer) {
     this.beer = beer;
+  }
+
+  private void updateMember(Member member) { this.member = member; }
+
+  public void setRecord(Beer beer, Record lastSavedRecord, Member member){
+    this.updateBeer(beer);
+    this.updateEndCountry(beer);
+    this.updateStartCountry(lastSavedRecord);
+    this.updateMember(member);
   }
 
   public void updateRecord(RecordUpdateRequestDto recordUpdateRequestDto, List<RecordFlavor> recordFlavors){


### PR DESCRIPTION
- ✨ 맥주 record 업데이트 및 조회 기능 추가
- ✨ 맥주 record 생성시 자동 level확인 및 적용
- ✨ 전체 level확인 API 생성
- 🎨 맥주 record 생성 기능 메서드 분리

## 📍 주요 변경사항


<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 💡 중점적으로 봐주었으면 하는 부분

- 맥주 생성 기능에서 조회하는 메서드를 분리하였는데, repository에서 검색해오는 방식은 service에서 진행됩니다.
    - 개인적으로 이렇게 하면 결국 record, beer, flavor등을 service에서 검색하는것을 진행해야 해서 결합도가 쓸데없이 올라가는 것 같은데, entity 내에서 repository를 사용하는것도 좀 그래서 이렇게 했는데요.... 혹시 인사이트가 있으시면 공유해주시면 감사하겠습니다!!!
- 추가로 저희가 현재 getById와 findById를 혼용해서 사용중인 것 같은데, 에러메세지를 따로 선언하여서 저는 find를 사용했습니다. 이부분에 대해 추가로 논의가 필요할 것 같습니다!
- public에서 setter역할로 사용되던 메서드를 하나의 set메서드로 변경하였는데, 이부분도 확인해주시면 감사하곘습니다!

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->