### PR TITLE
chore: 초기 배포 시 docker ps -qa 명령어 에러 분기 처리 제안

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -88,7 +88,13 @@ jobs:
             key: ${{ secrets.PRIVATE_KEY_PROD }}
             envs: GITHUB_SHA
             script: |
-                sudo docker rm -f $(docker ps -qa)
+                CONTAINERS=$(docker ps -qa)
+                if [ -z "$CONTAINERS" ];
+                then
+                  echo "container not exist"
+                else
+                  docker rm -f $(docker ps -qa)
+                fi
                 sudo docker pull ${{ steps.docker_meta.outputs.tags }}
                 docker run -d -p 8080:8080 --name prod ${{ steps.docker_meta.outputs.tags }}
 


### PR DESCRIPTION
## 📍 주요 변경사항
- 현재 91:`sudo docker rm -f $(docker ps -qa)` 부분에서 초기 서버 구성 때 존재하는 container가 없어서 에러가 발생할 것 같음
- 해당 부분 분기 처리

## 💡 중점적으로 봐주었으면 하는 부분
- 현재는 이미 배포중이라 문제없겠지만, 나중에 서버 이전 작업 등을 할 때는 에러가 발생할 수 있을 것 같아 다음과 같이 초기 구동 시 container가 존재하지 않는 경우에는 삭제 명령어를 실행하지 않도록 분기처리하는것도 좋을 것 같아 추가함
- 우선 제안이라 prod 환경으로 임시 PR 날렸슴다

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->